### PR TITLE
Fix/close conn and wrong protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+v1.5.1
+
+Fix:
+- Ignore wrong protocol connection  attempts in websocket endpoint
+- Ignore "use of closed network connection" by concurrent read write benign error
+  
 v1.5.0
 
 Added:


### PR DESCRIPTION
### https://sentry.dev.cloud.weni.ai/organizations/weni/issues/3760/?project=42&query=is%3Aunresolved
It happens when the socket receives a Get by http protocol instead of websocket ws protocol.

The solution would be to identify if any of our services is doing some healthcheck on the websocket connection route, which is /ws.

Palliative changes in this fix is avoid Logging these cases so as not to overload the application while there are these requests.
﻿
### https://sentry.dev.cloud.weni.ai/organizations/weni/issues/3759/?project=42&query=is%3Aunresolved
﻿
It happens with Chrome﻿ as a client, and the socket is behind a proxy (nginx, ngrok, traefik, etc...), the connection is closed by inactivity, or when the connection is closed by server side.

﻿The solution is Sending a ping message from the client to the server every x seconds seems to solve the problem, keeping the connection alive.

Palliative changes in this fix is improve the log to know the origin of these applications and avoid handle this like an error from application.