### PR TITLE
Fix: Remove S3 region from URL

### DIFF
--- a/pkg/websocket/helper.go
+++ b/pkg/websocket/helper.go
@@ -196,6 +196,6 @@ func uploadToS3(from string, file io.Reader, fileType string) (string, error) {
 		return "", err
 	}
 
-	url := fmt.Sprintf("https://%s.s3-%s.amazonaws.com/%s", config.Bucket, config.Region, key)
+	url := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", config.Bucket, key)
 	return url, nil
 }


### PR DESCRIPTION
Removing regions since it is not required and some S3 URLs are with `.` and others with `-` like:
- `https://bucket-name.s3-us-east-1.amazonaws.com`
- `https://bucket-name.s3.us-east-1.amazonaws.com`