### PR TITLE
tweak upgrade connection error handling

### DIFF
--- a/pkg/websocket/handler.go
+++ b/pkg/websocket/handler.go
@@ -31,14 +31,13 @@ func checkWebsocketProtocol(r *http.Request) bool {
 func (a *App) WSHandler(w http.ResponseWriter, r *http.Request) {
 	log.Trace("Serving websocket")
 
-	if !checkWebsocketProtocol(r) {
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("websocket: the client is not using the websocket protocol"))
-		return
-	}
-
 	conn, err := Upgrade(w, r)
 	if err != nil {
+		if !checkWebsocketProtocol(r) {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("websocket: the client is not using the websocket protocol"))
+			return
+		}
 		log.Error(err, r)
 		return
 	}


### PR DESCRIPTION
websocket.Upgrader.Upgrade() already check the protocols, now using checkWebsocketProtocol only to know if upgrade error is from a attempt for common http GET request. So in that case ignore and not spam log errors.